### PR TITLE
Designated deb/rpm based installations in documentation

### DIFF
--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -1376,10 +1376,18 @@ ln -s `which pkg-config` /home/builder/.termux-build/_cache/18-arm-21-v2/bin/arm
 
 <p>Install <a href="https://play.google.com/store/apps/details?id=ru.meefik.linuxdeploy">Linux Deploy</a>, <a href="https://play.google.com/store/apps/details?id=com.sonelli.juicessh">JuiceSSH</a>, in Linux Deploy install kalilinux_arm (u need the <a href="https://www.google.cl/search?q=piggy+helper+apk">piggy helper</a> and enable the SSH) and type:</p>
 
+<h5 id="deb-based distros">Debian-based Distros</h5>
 <pre><code>sudo apt update
 sudo apt install golang git build-essential libpcap-dev libusb-1.0-0-dev libnetfilter-queue-dev
 
 </code></pre>
+
+<h5 id="rpm-based distros">RPM-based Distros</h5>
+<pre><code>sudo dnf update
+sudo dnf install golang git kernel-devel-`uname -r` libpcap-14 libpcap-devel libusb-1 libusb-devel libnetfilter_queue-devel
+
+</code></pre>
+
 
 <p>You can now proceed with the compilation:</p>
 


### PR DESCRIPTION
Seeks to resolve Issue #10 by providing separate installation instructions for debian & RPM-based linux distributions respectively.