### PR TITLE
fix links to http[s] proxy caplets

### DIFF
--- a/content/modules/ethernet/proxies/http.proxy/_index.md
+++ b/content/modules/ethernet/proxies/http.proxy/_index.md
@@ -65,7 +65,7 @@ function onCommand(cmd) {
 }
 ```
 
-Modules can change the `req` request and `res` response objects, for instance the [web-override.cap caplet](https://github.com/bettercap/caplets/blob/master/web-override.cap) is using the `onRequest` function in order to override every request before it is executed with a fake response:
+Modules can change the `req` request and `res` response objects, for instance the [web-override.cap caplet](https://github.com/bettercap/caplets/blob/master/web-override/web-override.cap) is using the `onRequest` function in order to override every request before it is executed with a fake response:
 
 ```js
 function onRequest(req, res) {
@@ -81,7 +81,7 @@ function onRequest(req, res) {
 }
 ```
 
-The [login-man-abuse.cap caplet](https://github.com/bettercap/caplets/blob/master/login-man-abuse.cap) instead will use the `onResponse` handler to inject its malicious javascript file in every html response:
+The [login-man-abuse.cap caplet](https://github.com/bettercap/caplets/blob/master/login-manager-abuse/login-man-abuse.cap) instead will use the `onResponse` handler to inject its malicious javascript file in every html response:
 
 ```js
 function onResponse(req, res) {

--- a/content/modules/ethernet/proxies/https.proxy/_index.md
+++ b/content/modules/ethernet/proxies/https.proxy/_index.md
@@ -77,7 +77,7 @@ function onCommand(cmd) {
 }
 ```
 
-Modules can change the `req` request and `res` response objects, for instance the [web-override.cap caplet](https://github.com/bettercap/caplets/blob/master/web-override.cap) is using the `onRequest` function in order to override every request before it is executed with a fake response:
+Modules can change the `req` request and `res` response objects, for instance the [web-override.cap caplet](https://github.com/bettercap/caplets/blob/master/web-override/web-override.cap) is using the `onRequest` function in order to override every request before it is executed with a fake response:
 
 ```js
 function onRequest(req, res) {
@@ -93,7 +93,7 @@ function onRequest(req, res) {
 }
 ```
 
-The [login-man-abuse.cap caplet](https://github.com/bettercap/caplets/blob/master/login-man-abuse.cap) instead will use the `onResponse` handler to inject its malicious javascript file in every html response:
+The [login-man-abuse.cap caplet](https://github.com/bettercap/caplets/blob/master/login-manager-abuse/login-man-abuse.cap) instead will use the `onResponse` handler to inject its malicious javascript file in every html response:
 
 ```js
 function onResponse(req, res) {

--- a/docs/modules/ethernet/proxies/http.proxy/index.html
+++ b/docs/modules/ethernet/proxies/http.proxy/index.html
@@ -1424,7 +1424,7 @@ function onCommand(cmd) {
 }
 </code></pre>
 
-<p>Modules can change the <code>req</code> request and <code>res</code> response objects, for instance the <a href="https://github.com/bettercap/caplets/blob/master/web-override.cap">web-override.cap caplet</a> is using the <code>onRequest</code> function in order to override every request before it is executed with a fake response:</p>
+<p>Modules can change the <code>req</code> request and <code>res</code> response objects, for instance the <a href="https://github.com/bettercap/caplets/blob/master/web-override/web-override.cap">web-override.cap caplet</a> is using the <code>onRequest</code> function in order to override every request before it is executed with a fake response:</p>
 
 <pre><code class="language-js">function onRequest(req, res) {
     res.Status      = 200;
@@ -1439,7 +1439,7 @@ function onCommand(cmd) {
 }
 </code></pre>
 
-<p>The <a href="https://github.com/bettercap/caplets/blob/master/login-man-abuse.cap">login-man-abuse.cap caplet</a> instead will use the <code>onResponse</code> handler to inject its malicious javascript file in every html response:</p>
+<p>The <a href="https://github.com/bettercap/caplets/blob/master/login-manager-abuse/login-man-abuse.cap">login-man-abuse.cap caplet</a> instead will use the <code>onResponse</code> handler to inject its malicious javascript file in every html response:</p>
 
 <pre><code class="language-js">function onResponse(req, res) {
     if( res.ContentType.indexOf('text/html') == 0 ){

--- a/docs/modules/ethernet/proxies/https.proxy/index.html
+++ b/docs/modules/ethernet/proxies/https.proxy/index.html
@@ -1475,7 +1475,7 @@ function onCommand(cmd) {
 }
 </code></pre>
 
-<p>Modules can change the <code>req</code> request and <code>res</code> response objects, for instance the <a href="https://github.com/bettercap/caplets/blob/master/web-override.cap">web-override.cap caplet</a> is using the <code>onRequest</code> function in order to override every request before it is executed with a fake response:</p>
+<p>Modules can change the <code>req</code> request and <code>res</code> response objects, for instance the <a href="https://github.com/bettercap/caplets/blob/master/web-override/web-override.cap">web-override.cap caplet</a> is using the <code>onRequest</code> function in order to override every request before it is executed with a fake response:</p>
 
 <pre><code class="language-js">function onRequest(req, res) {
     res.Status      = 200;
@@ -1490,7 +1490,7 @@ function onCommand(cmd) {
 }
 </code></pre>
 
-<p>The <a href="https://github.com/bettercap/caplets/blob/master/login-man-abuse.cap">login-man-abuse.cap caplet</a> instead will use the <code>onResponse</code> handler to inject its malicious javascript file in every html response:</p>
+<p>The <a href="https://github.com/bettercap/caplets/blob/master/login-manager-abuse/login-man-abuse.cap">login-man-abuse.cap caplet</a> instead will use the <code>onResponse</code> handler to inject its malicious javascript file in every html response:</p>
 
 <pre><code class="language-js">function onResponse(req, res) {
     if( res.ContentType.indexOf('text/html') == 0 ){


### PR DESCRIPTION
Just a minor bugfix regarding links of http[s] proxy caplets.