### PR TITLE
Updated minimum Go environment

### DIFF
--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -1540,7 +1540,7 @@ a.highlight span.copy-to-clipboard {
 <h2 id="compiling-from-sources">Compiling from Sources</h2>
 <p>In order to compile bettercap from sources, make sure that:</p>
 <ul>
-<li>You have a correctly configured <strong><a href="https://golang.org/doc/install">Go &gt;= 1.8</a></strong> environment.</li>
+<li>You have a correctly configured <strong><a href="https://golang.org/doc/install">Go &gt;= 1.13</a></strong> environment.</li>
 <li><code>$GOPATH</code> is defined and <code>$GOPATH/bin</code> is in <code>$PATH</code>.</li>
 <li>For hardware with limited resources (like Raspberry Pi Zero boards) you might want <a href="https://www.bitpi.co/2015/02/11/how-to-change-raspberry-pis-swapfile-size-on-rasbian/">to increase the swap size</a>.</li>
 </ul>


### PR DESCRIPTION
The functionality of crypto/ed25519 was moved into the standard library in Go 1.13, using a previous version causes the following errors
'package crypto/ed25519: unrecognized import path "crypto/ed25519" (import path does not begin with hostname)'
Resulting in tickets such as https://github.com/bettercap/bettercap/issues/880