### PR TITLE
Outdated go command in Installation page

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -90,7 +90,7 @@ sudo apt install golang git build-essential libpcap-dev libusb-1.0-0-dev libnetf
 You can now proceed with the compilation:
 
 ```sh
-go get -u github.com/bettercap/bettercap
+go install github.com/bettercap/bettercap@latest
 ```
 
 Once the build process is concluded, the binary will be located in `go/bin/bettercap`.


### PR DESCRIPTION
Command 
```
go get -u github.com/bettercap/bettercap
```
throws the error:
```
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```