### PR TITLE
update website installation content for "Linux Deploy Method Debian based (Like Ubuntu)"

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -92,6 +92,19 @@ You can now proceed with the compilation:
 ```sh
 go get -u github.com/bettercap/bettercap
 ```
+^^^
+DOESN'T WORK IN KALI LINUX
+```
+go install github.com/bettercap/bettercap@latest
+```
+AND THEN RUN THESE COMMAND TO INSTALL THE BINARY FILE I GUESS
+```
+cd go/bin/ && sudo apt install bettercap
+```
+AND FINALLY YOU CAN DO THIS TO ENJOY THE FUNCTIONALITY
+```
+sudo bettercap
+```
 
 Once the build process is concluded, the binary will be located in `go/bin/bettercap`.
 


### PR DESCRIPTION
When running line#93, it raises an error in Kali linux terminal: 
```
$ go get -u github.com/bettercap/bettercap                                                            
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
Suggested commands to run are added in the file.