### PR TITLE
Linux Deploy Method Debian based (Like Ubuntu) Installation issue Fixed

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -90,7 +90,7 @@ sudo apt install golang git build-essential libpcap-dev libusb-1.0-0-dev libnetf
 You can now proceed with the compilation:
 
 ```sh
-go get -u github.com/bettercap/bettercap
+go install github.com/bettercap/bettercap@latest
 ```
 
 Once the build process is concluded, the binary will be located in `go/bin/bettercap`.


### PR DESCRIPTION
When using original command (go get -u github.com/bettercap/bettercap) I was given the following error message: "'go get' is no longer supported outside a module." Since using "go get" to install executables has been deprecated starting at Go 1.17, I think it is best to change the documentation to use "go install".