### PR TITLE
Update _index.md

### DIFF
--- a/content/modules/wifi/_index.md
+++ b/content/modules/wifi/_index.md
@@ -67,7 +67,7 @@ Show WPS information about a given station (use `all`, `*` or `ff:ff:ff:ff:ff:ff
 
 #### `wifi.recon.channel CHANNEL` 
 
-Comma separated list of channels to hop on.
+Comma separated list of channels to hop on while wifi.recon is active.
 
 #### `wifi.recon.channel clear`
 
@@ -136,7 +136,7 @@ Sort by BSSID and filter for BSSIDs starting with `F4`:
 Only recon on channels 1, 2 and 3:
 
 ```
-> wifi.recon.channel 1,2,3; wifi.recon on
+> wifi.recon on; wifi.recon.channel 1,2,3
 ```
 
 Will send management beacons as the fake access point "Banana" with BSSID `DE:AD:BE:EF:DE:AD` on channel 5 without encryption:


### PR DESCRIPTION
Fix wifi.recon.channel documentation. Preference gets reset when wifi.recon is toggled on though documentation doesn't reflect this. Might be better off as a set/get variable.

#### Further explanation


Bettercap ignores `wifi.recon.channel` if set before invoking `wifi.recon on`. `wifi.recon.channel` Must be called _**after**_ `wifi.recon on` to have an impact.

For example - trying to avoid channels which the network interface describes as `disabled` under example command `iw phy phy0 info |grep -E '[0-9]{4} MHz'` with `wifi.recon.channel x,y,z` is entirely ignored when set before `wifi.recon on` gets issued.