### PR TITLE
Updated package name on fedora

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -99,6 +99,6 @@ Once the build process is concluded, the binary will be located in `go/bin/bette
 #### Linux Deploy Method Fedora based (like Redhat, Centos)
 ```
 sudo dnf update
-sudo dnf install golang git make automake gcc gcc-c++ kernel-devel libpcap-devel libusb-devel libnetfilter_queue-devel
+sudo dnf install golang git make automake gcc gcc-c++ kernel-devel libpcap-devel libusb1-devel libnetfilter_queue-devel
 
 ```


### PR DESCRIPTION
`libusb-devel` doesn't exist, it was changed to `libusb1-devel`
[libusb-devel](https://packages.fedoraproject.org/pkgs/libusb/libusb-devel/) hasn't had a release till Fedora 36
[libusb1-devel](https://packages.fedoraproject.org/pkgs/libusb1/libusb1-devel/) libusb1-devel has had a release since Fedora 38
