### PR TITLE
Add pkg_config dependency to content/installation/_index.md

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -11,6 +11,7 @@ weight: 3
 
 In order to be able to use bettercap, you'll need the following dependencies on your system:
 
+* pkg-config
 * libpcap
 * libusb-1.0-0 (required by the [HID module](/modules/hid/))
 * libnetfilter-queue (on Linux only, required by the [packet.proxy module](/modules/ethernet/proxies/packet.proxy/))


### PR DESCRIPTION
` go install github.com/bettercap/bettercap@latest ` fails with `github.com/google/gousb: exec: "pkg-config": executable file not found in $PATH` during installation.

`pkg-config` should be added to the instructions for installations from source.

 ```
% go install github.com/bettercap/bettercap@latest

go: finding module for package github.com/evilsocket/islazy/str
go: finding module for package github.com/bettercap/readline
go: finding module for package github.com/gorilla/mux
go: finding module for package github.com/gorilla/websocket
go: finding module for package github.com/bettercap/recording
go: finding module for package github.com/evilsocket/islazy/log
go: finding module for package github.com/evilsocket/islazy/tui
go: finding module for package github.com/malfunkt/iprange
go: finding module for package github.com/evilsocket/islazy/fs
go: finding module for package github.com/evilsocket/islazy/data
go: finding module for package github.com/dustin/go-humanize
go: finding module for package github.com/evilsocket/islazy/ops
go: finding module for package github.com/evilsocket/islazy/zip
go: finding module for package github.com/google/gopacket
go: finding module for package github.com/google/gopacket/layers
go: finding module for package github.com/google/gopacket/pcap
go: finding module for package github.com/mdlayher/dhcp6
go: finding module for package github.com/mdlayher/dhcp6/dhcp6opts
go: finding module for package github.com/gobwas/glob
go: finding module for package github.com/antchfx/jsonquery
go: finding module for package github.com/google/go-github/github
go: finding module for package github.com/adrianmo/go-nmea
go: finding module for package github.com/tarm/serial
go: finding module for package github.com/bettercap/nrf24
go: finding module for package github.com/google/gousb
go: finding module for package github.com/elazarl/goproxy
go: finding module for package github.com/evilsocket/islazy/plugin
go: finding module for package github.com/inconshreveable/go-vhost
go: finding module for package github.com/jpillora/go-tld
go: finding module for package github.com/hashicorp/mdns
go: finding module for package github.com/robertkrimen/otto
go: finding module for package github.com/google/gopacket/pcapgo
go: finding module for package github.com/evilsocket/islazy/async
go: finding module for package github.com/miekg/dns
go: finding module for package golang.org/x/net/html
go: found github.com/evilsocket/islazy/str in github.com/evilsocket/islazy v1.11.0
go: found github.com/evilsocket/islazy/tui in github.com/evilsocket/islazy v1.11.0
go: found github.com/evilsocket/islazy/log in github.com/evilsocket/islazy v1.11.0
go: found github.com/bettercap/readline in github.com/bettercap/readline v0.0.0-20210228151553-655e48bcb7bf
go: found github.com/dustin/go-humanize in github.com/dustin/go-humanize v1.0.1
go: found github.com/evilsocket/islazy/data in github.com/evilsocket/islazy v1.11.0
go: found github.com/evilsocket/islazy/fs in github.com/evilsocket/islazy v1.11.0
go: found github.com/evilsocket/islazy/ops in github.com/evilsocket/islazy v1.11.0
go: found github.com/bettercap/recording in github.com/bettercap/recording v0.0.0-20190408083647-3ce1dcf032e3
go: found github.com/gorilla/mux in github.com/gorilla/mux v1.8.1
go: found github.com/gorilla/websocket in github.com/gorilla/websocket v1.5.3
go: found github.com/malfunkt/iprange in github.com/malfunkt/iprange v0.9.0
go: found github.com/evilsocket/islazy/zip in github.com/evilsocket/islazy v1.11.0
go: found github.com/google/gopacket in github.com/google/gopacket v1.1.19
go: found github.com/google/gopacket/layers in github.com/google/gopacket v1.1.19
go: found github.com/google/gopacket/pcap in github.com/google/gopacket v1.1.19
go: found github.com/mdlayher/dhcp6 in github.com/mdlayher/dhcp6 v0.0.0-20190311162359-2a67805d7d0b
go: found github.com/mdlayher/dhcp6/dhcp6opts in github.com/mdlayher/dhcp6 v0.0.0-20190311162359-2a67805d7d0b
go: found github.com/gobwas/glob in github.com/gobwas/glob v0.2.3
go: found github.com/antchfx/jsonquery in github.com/antchfx/jsonquery v1.3.5
go: found github.com/google/go-github/github in github.com/google/go-github v17.0.0+incompatible
go: found github.com/adrianmo/go-nmea in github.com/adrianmo/go-nmea v1.10.0
go: found github.com/tarm/serial in github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
go: found github.com/bettercap/nrf24 in github.com/bettercap/nrf24 v0.0.0-20190219153547-aa37e6d0e0eb
go: found github.com/google/gousb in github.com/google/gousb v1.1.3
go: found github.com/elazarl/goproxy in github.com/elazarl/goproxy v0.0.0-20240726154733-8b0c20506380
go: found github.com/evilsocket/islazy/plugin in github.com/evilsocket/islazy v1.11.0
go: found github.com/inconshreveable/go-vhost in github.com/inconshreveable/go-vhost v1.0.0
go: found github.com/jpillora/go-tld in github.com/jpillora/go-tld v1.2.1
go: found github.com/robertkrimen/otto in github.com/robertkrimen/otto v0.4.0
go: found github.com/hashicorp/mdns in github.com/hashicorp/mdns v1.0.5
go: found github.com/google/gopacket/pcapgo in github.com/google/gopacket v1.1.19
go: found github.com/evilsocket/islazy/async in github.com/evilsocket/islazy v1.11.0
go: found github.com/miekg/dns in github.com/miekg/dns v1.1.62
go: found golang.org/x/net/html in golang.org/x/net v0.28.0
go: finding module for package github.com/google/go-querystring/query
go: finding module for package github.com/kr/binarydist
go: finding module for package github.com/pkg/errors
go: found github.com/kr/binarydist in github.com/kr/binarydist v0.1.0
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
go: found github.com/google/go-querystring/query in github.com/google/go-querystring v1.1.0
github.com/google/gousb: exec: "pkg-config": executable file not found in $PATH
```