### PR TITLE
fix go install command on /installation page

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -18,7 +18,7 @@ In order to be able to use bettercap, you'll need the following dependencies on 
 
 ## Installing via Go
 
-    go install github.com/bettercap/bettercap@latest 
+    go install github.com/bettercap/bettercap/v2@latest 
 
 ## Using Docker
 


### PR DESCRIPTION
the original install command doesn't work with modern versions of golang because it needs to specify version 2:
```bash
$ go install github.com/bettercap/bettercap@latest 
go: github.com/bettercap/bettercap@latest: no matching versions for query "latest"
```

but ` go install github.com/bettercap/bettercap/v2@latest` works