### PR TITLE
feat: Add default username and password for API

### DIFF
--- a/src/content/docs/modules/core/api.rest.md
+++ b/src/content/docs/modules/core/api.rest.md
@@ -3,6 +3,14 @@ title: api.rest
 description: A RESTful API server to orchestrate and interact with the current interactive session, starts on HTTP and unauthenticated by default, can be switched to HTTPS and basic auth by using the proper parameters.
 ---
 
+:::note
+The default credentials are:
+
+- **Username**: `user`
+- **Password**: `pass`
+
+:::
+
 A RESTful API server to orchestrate and interact with the current interactive session, starts on HTTP and unauthenticated by default, can be switched to HTTPS and basic auth by using the proper parameters.
 
 ### Commands
@@ -45,10 +53,10 @@ Stop replaying the recorded session.
 | `api.rest.certificate.organization`       | `bettercap devteam`      | Organization field of the generated HTTPS certificate.                                              |
 | `api.rest.certificate.organizationalunit` | `https://bettercap.org/` | Organizational Unit field of the generated HTTPS certificate.                                       |
 | `api.rest.key`                            |                          | API TLS key (will be auto generated if not existing), fill to enable HTTPS.                         |
-| `api.rest.password`                       |                          | API HTTP basic auth password.                                                                       |
+| `api.rest.password`                       | `pass`                   | API HTTP basic auth password.                                                                       |
 | `api.rest.port`                           | `8081`                   | Port to bind the API REST server to.                                                                |
 | `api.rest.record.clock`                   | `1`                      | Number of seconds to wait while recording with api.rest.record between one sample and the next one. |
-| `api.rest.username`                       |                          | API HTTP basic auth username.                                                                       |
+| `api.rest.username`                       | `user`                   | API HTTP basic auth username.                                                                       |
 | `api.rest.websocket`                      | `false`                  | If true the `/api/events` route will be available as a websocket endpoint instead of HTTP.          |
 
 ### Routes

--- a/src/content/docs/modules/ethernet/servers/http.server.md
+++ b/src/content/docs/modules/ethernet/servers/http.server.md
@@ -19,9 +19,9 @@ Stop the HTTP server in the background.
 
 | Parameter             | Default               | Description                         |
 | --------------------- | --------------------- | ----------------------------------- |
-| `http.server.address` | `<interface address>` | Address to bind the http server to. |
+| `http.server.address` | `<interface address>` | Address to bind the HTTP server to. |
 | `http.server.path`    | `.`                   | Server folder.                      |
-| `http.server.port`    | `80`                  | Port to bind the http server to.    |
+| `http.server.port`    | `80`                  | Port to bind the HTTP server to.    |
 
 ### Examples
 

--- a/src/content/docs/modules/ethernet/servers/https.server.md
+++ b/src/content/docs/modules/ethernet/servers/https.server.md
@@ -9,17 +9,17 @@ A simple HTTPS server, used to serve files and scripts across the network.
 
 #### `https.server on`
 
-Start the HTTP server in the background.
+Start the HTTPS server in the background.
 
 #### `https.server off`
 
-Stop the HTTP server in the background.
+Stop the HTTPS server in the background.
 
 ### Parameters
 
 | Parameter                                     | Default                       | Description                                                               |
 | --------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------- |
-| `https.server.address`                        | `<interface address>`         | Address to bind the http server to.                                       |
+| `https.server.address`                        | `<interface address>`         | Address to bind the HTTPS server to.                                      |
 | `https.server.certificate`                    | `~/.bettercap-https.cert.pem` | TLS certificate file (will be auto generated if filled but not existing). |
 | `https.server.certificate.bits`               | `4096`                        | Number of bits of the RSA private key of the generated HTTPS certificate. |
 | `https.server.certificate.commonname`         | `bettercap`                   | Common Name field of the generated HTTPS certificate.                     |
@@ -29,7 +29,7 @@ Stop the HTTP server in the background.
 | `https.server.certificate.organizationalunit` | `https://bettercap.org/`      | Organizational Unit field of the generated HTTPS certificate.             |
 | `https.server.key`                            | `~/.bettercap-https.key.pem`  | TLS key file (will be auto generated if filled but not existing).         |
 | `https.server.path`                           | `.`                           | Server folder.                                                            |
-| `https.server.port`                           | `443`                         | Port to bind the http server to.                                          |
+| `https.server.port`                           | `443`                         | Port to bind the HTTPS server to.                                         |
 
 ### Examples
 


### PR DESCRIPTION
Set the default username and password for the API, hence the UI to:

- **Username**: `user`
- **Password**: `pass`

Also fixes consistency between the descriptions of the HTTP(S) servers.